### PR TITLE
fix(ROS_HOME): env variable only necessary for navigation and mapping

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,31 +54,23 @@ parts:
 apps:
   core:
     daemon: simple
-    environment:
-      ROS_HOME: $SNAP_USER_DATA/ros
     command: usr/bin/core_launcher.sh
     plugs: [network, network-bind, raw-usb]
     extensions: [ros1-noetic]
 
   teleop:
     daemon: simple
-    environment:
-      ROS_HOME: $SNAP_USER_DATA/ros
     command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop turtlebot3c_teleop.launch
     plugs: [network, network-bind]
     extensions: [ros1-noetic]
 
   key:
-    environment:
-      ROS_HOME: $SNAP_USER_DATA/ros
     command-chain: [usr/bin/mux_select_key_vel.sh]
     command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop key.launch
     plugs: [network, network-bind]
     extensions: [ros1-noetic]
 
   joy:
-    environment:
-      ROS_HOME: $SNAP_USER_DATA/ros
     command-chain: [usr/bin/mux_select_joy_vel.sh]
     command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop joy.launch
     plugs: [network, network-bind, joystick]


### PR DESCRIPTION
This is due to rospack using a non-standard way to define the home of a user

[Rospack](http://wiki.ros.org/rospack) doesn’t use the $HOME environment variable but [uses the password structure to get the home directory](https://github.com/ros/rospack/blob/ad85a874575bbed74124b722b42b545537cc6aa3/src/rospack.cpp#L1951). By default, snaps make sure that the environment variable $HOME is pointing to a writable directory, but unfortunately rospack is not using it. The good news is that rospack[ first tries to read the $ROS_HOME](https://github.com/ros/rospack/blob/ad85a874575bbed74124b722b42b545537cc6aa3/src/rospack.cpp#L1935).