### PR TITLE
fix(configure): service restart

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -37,6 +37,8 @@ case "$TURTLEBOT3_MODEL" in
 esac
 
 # restart core and teleop on new config
-snapctl restart "$SNAP_INSTANCE_NAME.core"
-snapctl restart "$SNAP_INSTANCE_NAME.teleop"
+snapctl stop "$SNAP_INSTANCE_NAME.core"
+snapctl stop "$SNAP_INSTANCE_NAME.teleop"
 
+snapctl start "$SNAP_INSTANCE_NAME.core"
+snapctl start "$SNAP_INSTANCE_NAME.teleop"


### PR DESCRIPTION
Using the restart keyword, is not working so good. XMLRPC is failing to access the port.
Stop and then start works,
The error most probably comes from the roscore.
Since we restart the `core` application and then the `teleop` application.
The error was:
```
Exception ignored in thread started by: <bound method XmlRpcNode.run of <rosgraph.xmlrpc.XmlRpcNode object at 0x7f974b8a3e50>>
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]: Traceback (most recent call last):
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/snap/turtlebot3c/x2/opt/ros/noetic/lib/python3/dist-packages/rosgraph/xmlrpc.py", line 249, in run
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     self._run()
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/snap/turtlebot3c/x2/opt/ros/noetic/lib/python3/dist-packages/rosgraph/xmlrpc.py", line 318, in _run
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     self._run_init()
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/snap/turtlebot3c/x2/opt/ros/noetic/lib/python3/dist-packages/rosgraph/xmlrpc.py", line 268, in _run_init
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     self.server = ThreadingXMLRPCServer((bind_address, port), log_requests)
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/snap/turtlebot3c/x2/opt/ros/noetic/lib/python3/dist-packages/rosgraph/xmlrpc.py", line 146, in __init__
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     SimpleXMLRPCServer.__init__(self, addr, SilenceableXMLRPCRequestHandler, log_requests)
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/usr/lib/python3.8/xmlrpc/server.py", line 605, in __init__
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     socketserver.TCPServer.__init__(self, addr, requestHandler, bind_and_activate)
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/usr/lib/python3.8/socketserver.py", line 452, in __init__
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     self.server_bind()
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:   File "/usr/lib/python3.8/socketserver.py", line 466, in server_bind
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]:     self.socket.bind(self.server_address)
2023-03-07T17:21:45+01:00 turtlebot3c.core[126957]: OSError: [Errno 98] Address already in use
```