### PR TITLE
Fix/tb3 prague kria

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,3 +9,6 @@ snapctl set lds-model=LDS-01
 # set default turtlebot 3 model
 snapctl set turtlebot3-model=waffle_pi
 
+# set default ROS master hostname
+snapctl set ros-master-host=$(hostname).local
+

--- a/snap/local/ros_network.sh
+++ b/snap/local/ros_network.sh
@@ -2,7 +2,9 @@
 
 ROS_MASTER_HOST="$(snapctl get ros-master-host)"
 
-export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
+if [[ -z "${ROS_MASTER_URI}" ]]; then
+    export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
+fi
 export ROS_IP=${ROS_MASTER_HOST}
 
 exec $@

--- a/snap/local/ros_network.sh
+++ b/snap/local/ros_network.sh
@@ -5,7 +5,9 @@ ROS_MASTER_HOST="$(snapctl get ros-master-host)"
 if [[ -z "${ROS_MASTER_URI}" ]]; then
     export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
 fi
-export ROS_IP=${ROS_MASTER_HOST}
+if [[ -z "${ROS_HOSTNAME}" ]]; then
+    export ROS_HOSTNAME=${ROS_MASTER_HOST}
+fi
 
 exec $@
 

--- a/snap/local/ros_network.sh
+++ b/snap/local/ros_network.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+ROS_MASTER_HOST="$(snapctl get ros-master-host)"
+
+export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
+export ROS_IP=${ROS_MASTER_HOST}
+
+exec $@
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ apps:
     daemon: simple
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
+      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack"
     command: usr/bin/core_launcher.sh
     plugs: [network, network-bind, raw-usb]
     extensions: [ros1-noetic]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -101,8 +101,8 @@ apps:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
       # map server need pulseaudio
-      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio"
     command-chain: [usr/bin/mux_select_nav_vel.sh]
+      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
     command: usr/bin/navigation_launcher.sh
     daemon: simple
     install-mode: disable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,7 @@ apps:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
       LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack"
+    command-chain: [usr/bin/ros_network.sh]
     command: usr/bin/core_launcher.sh
     plugs: [network, network-bind, raw-usb]
     extensions: [ros1-noetic]
@@ -65,6 +66,7 @@ apps:
     daemon: simple
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
+    command-chain: [usr/bin/ros_network.sh]
     command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop turtlebot3c_teleop.launch
     plugs: [network, network-bind]
     extensions: [ros1-noetic]
@@ -72,7 +74,7 @@ apps:
   key:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
-    command-chain: [usr/bin/mux_select_key_vel.sh]
+    command-chain: [usr/bin/ros_network.sh, usr/bin/mux_select_key_vel.sh]
     command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop key.launch
     plugs: [network, network-bind]
     extensions: [ros1-noetic]
@@ -80,7 +82,7 @@ apps:
   joy:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
-    command-chain: [usr/bin/mux_select_joy_vel.sh]
+    command-chain: [usr/bin/ros_network.sh, usr/bin/mux_select_joy_vel.sh]
     command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop joy.launch
     plugs: [network, network-bind, joystick]
     extensions: [ros1-noetic]
@@ -88,7 +90,7 @@ apps:
   mapping:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
-    command-chain: [usr/bin/mux_select_key_vel.sh]
+    command-chain: [usr/bin/ros_network.sh, usr/bin/mux_select_key_vel.sh]
     command: usr/bin/mapping_launcher.sh
     daemon: simple
     install-mode: disable
@@ -101,8 +103,8 @@ apps:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
       # map server need pulseaudio
-    command-chain: [usr/bin/mux_select_nav_vel.sh]
       LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+    command-chain: [usr/bin/ros_network.sh, usr/bin/mux_select_nav_vel.sh]
     command: usr/bin/navigation_launcher.sh
     daemon: simple
     install-mode: disable


### PR DESCRIPTION
This PR solves issues faced when running the snap on ARM.

- Proper export of the libblas library path
- PulseAudio path working with every architecture
- ROS network in order to be able to communicate easily with the snap from another computer on the same local network

Regarding the last point. It is working, but maybe we don't want to use the hostname.local but rather the locahost.