### PR TITLE
Fix/new prefix

### DIFF
--- a/snap/local/core_launcher.sh
+++ b/snap/local/core_launcher.sh
@@ -7,5 +7,5 @@ TURTLEBOT3_MODEL="$(snapctl get turtlebot3-model)"
 export LDS_MODEL
 export TURTLEBOT3_MODEL
 
-${SNAP}/opt/ros/noetic/bin/roslaunch turtlebot3c_bringup turtlebot3c_bringup.launch simulation:=$SIMULATION
+${SNAP}/roslaunch turtlebot3c_bringup turtlebot3c_bringup.launch simulation:=$SIMULATION
 

--- a/snap/local/mapping_launcher.sh
+++ b/snap/local/mapping_launcher.sh
@@ -4,5 +4,5 @@ TURTLEBOT3_MODEL="$(snapctl get turtlebot3-model)"
 
 export TURTLEBOT3_MODEL
 
-${SNAP}/opt/ros/noetic/bin/roslaunch turtlebot3c_2dnav turtlebot3c_mapping.launch
+${SNAP}/roslaunch turtlebot3c_2dnav turtlebot3c_mapping.launch
 

--- a/snap/local/navigation_launcher.sh
+++ b/snap/local/navigation_launcher.sh
@@ -5,7 +5,7 @@ TURTLEBOT3_MODEL="$(snapctl get turtlebot3-model)"
 export TURTLEBOT3_MODEL
 
 if [ -f "${SNAP_USER_COMMON}/map/current_map.yaml" ]; then
-  ${SNAP}/opt/ros/noetic/bin/roslaunch turtlebot3c_2dnav turtlebot3c_navigation.launch
+  ${SNAP}/roslaunch turtlebot3c_2dnav turtlebot3c_navigation.launch
 else
   >&2 echo "File ${SNAP_USER_COMMON}/map/current_map.yaml does not exist." \
     "Have you run the mapping application?"

--- a/snap/local/save_map.sh
+++ b/snap/local/save_map.sh
@@ -3,5 +3,5 @@
 # make map directory if not existing
 mkdir -p ${SNAP_USER_COMMON}/map
 
-$SNAP/opt/ros/noetic/bin/rosrun map_server map_saver -f "${SNAP_USER_COMMON}/map/new_map"
+$SNAP/rosrun map_server map_saver -f "${SNAP_USER_COMMON}/map/new_map"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,7 @@ apps:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
     command-chain: [usr/bin/ros_network.sh]
-    command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop turtlebot3c_teleop.launch
+    command: roslaunch turtlebot3c_teleop turtlebot3c_teleop.launch
     plugs: [network, network-bind]
     extensions: [ros1-noetic]
 
@@ -75,7 +75,7 @@ apps:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
     command-chain: [usr/bin/ros_network.sh, usr/bin/mux_select_key_vel.sh]
-    command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop key.launch
+    command: roslaunch turtlebot3c_teleop key.launch
     plugs: [network, network-bind]
     extensions: [ros1-noetic]
 
@@ -83,7 +83,7 @@ apps:
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
     command-chain: [usr/bin/ros_network.sh, usr/bin/mux_select_joy_vel.sh]
-    command: opt/ros/noetic/bin/roslaunch turtlebot3c_teleop joy.launch
+    command: roslaunch turtlebot3c_teleop joy.launch
     plugs: [network, network-bind, joystick]
     extensions: [ros1-noetic]
 


### PR DESCRIPTION
Thanks to new snapcraft stable version, we can now directly use the roslaunch/rosrun prefix

Tested with the simulation