### PR TITLE
Add connect hooks

### DIFF
--- a/turtlebot3c-bringup-snap/snap/hooks/connect-plug-ros-noetic
+++ b/turtlebot3c-bringup-snap/snap/hooks/connect-plug-ros-noetic
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# now we can start the service
+if snapctl services ${SNAP_NAME}.core | grep -q inactive; then
+  snapctl start --enable ${SNAP_NAME}.core 2>&1 || true
+fi

--- a/turtlebot3c-bringup-snap/snap/hooks/disconnect-plug-ros-noetic
+++ b/turtlebot3c-bringup-snap/snap/hooks/disconnect-plug-ros-noetic
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+snapctl stop --disable ${SNAP_NAME}.core 2>&1 || true

--- a/turtlebot3c-bringup-snap/snap/hooks/install
+++ b/turtlebot3c-bringup-snap/snap/hooks/install
@@ -12,3 +12,7 @@ snapctl set turtlebot3-model=waffle_pi
 # set default ROS master hostname
 snapctl set ros-master-host=$(hostname).local
 
+if ! snapctl is-connected ros-noetic; then
+  logger -t ${SNAP_NAME} "Plug 'ros-noetic' isn't connected, \
+    please run: snap connect ${SNAP_NAME}:ros-noetic <providing-snap>"
+fi

--- a/turtlebot3c-bringup-snap/snap/snapcraft.yaml
+++ b/turtlebot3c-bringup-snap/snap/snapcraft.yaml
@@ -49,6 +49,7 @@ parts:
 apps:
   core:
     daemon: simple
+    install-mode: disable
     environment:
       ROS_HOME: $SNAP_USER_DATA/ros
       # LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack"

--- a/turtlebot3c-nav-snap/snap/hooks/install
+++ b/turtlebot3c-nav-snap/snap/hooks/install
@@ -5,3 +5,8 @@ snapctl set turtlebot3-model=waffle_pi
 
 # set default ROS master hostname
 snapctl set ros-master-host=$(hostname).local
+
+if ! snapctl is-connected ros-noetic; then
+  logger -t ${SNAP_NAME} "Plug 'ros-noetic' isn't connected, \
+    please run: snap connect ${SNAP_NAME}:ros-noetic <providing-snap>"
+fi

--- a/turtlebot3c-teleop-snap/snap/hooks/install
+++ b/turtlebot3c-teleop-snap/snap/hooks/install
@@ -5,3 +5,8 @@ snapctl set turtlebot3-model=waffle_pi
 
 # set default ROS master hostname
 snapctl set ros-master-host=$(hostname).local
+
+if ! snapctl is-connected ros-noetic; then
+  logger -t ${SNAP_NAME} "Plug 'ros-noetic' isn't connected, \
+    please run: snap connect ${SNAP_NAME}:ros-noetic <providing-snap>"
+fi


### PR DESCRIPTION
Add hooks to allow tutlebot3c-bringup.core service to be enabled once the snap is connected to the foundational ros snap.