### PR TITLE
fix(ci): monthly snap publish

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -23,8 +23,7 @@ jobs:
       ubuntu-image: ubuntu-20.04
       branch-name: ${{ inputs.branch-name == '' && github.ref || inputs.branch-name }}
       snap-name: turtlebot3c
-      snap-install-args: --dangerous
-      publish: ${{ github.event_name == 'push' || inputs.branch-name != '' }}
+      publish: ${{ github.event_name == 'push' || ${{ github.event_name == 'workflow_dispatch' && inputs.branch-name != '' }} }}
       test-script: |
                     #!/bin/bash
 

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -23,7 +23,7 @@ jobs:
       ubuntu-image: ubuntu-20.04
       branch-name: ${{ inputs.branch-name == '' && github.ref || inputs.branch-name }}
       snap-name: turtlebot3c
-      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.branch-name != '' ) }}
+      publish: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
       test-script: |
                     #!/bin/bash
 

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -23,7 +23,7 @@ jobs:
       ubuntu-image: ubuntu-20.04
       branch-name: ${{ inputs.branch-name == '' && github.ref || inputs.branch-name }}
       snap-name: turtlebot3c
-      publish: ${{ github.event_name == 'push' || ${{ github.event_name == 'workflow_dispatch' && inputs.branch-name != '' }} }}
+      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.branch-name != '' ) }}
       test-script: |
                     #!/bin/bash
 

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -24,7 +24,7 @@ jobs:
       branch-name: ${{ inputs.branch-name == '' && github.ref || inputs.branch-name }}
       snap-name: turtlebot3c
       snap-install-args: --dangerous
-      publish: ${{ github.event_name == 'push' || github.event_name == 'workflow_call'}}
+      publish: ${{ github.event_name == 'push' || inputs.branch-name != '' }}
       test-script: |
                     #!/bin/bash
 


### PR DESCRIPTION
During a workflow call the variable github.event_name still evaluates to workflow_dispatch.

So there is no way to distinguish between a call and a dispatch.
Thus we use the input branch name.

https://github.com/actions/runner/discussions/1884