### PR TITLE
fix(ros_network): ROS_MASTER_URI is defined in advance by ros-extensi…

### DIFF
--- a/turtlebot3c-bringup-snap/snap/local/ros_network.sh
+++ b/turtlebot3c-bringup-snap/snap/local/ros_network.sh
@@ -2,7 +2,7 @@
 
 ROS_MASTER_HOST="$(snapctl get ros-master-host)"
 
-if [[ -z "${ROS_MASTER_URI}" ]]; then
+if [ "${ROS_MASTER_URI}" == "http://localhost:11311" ]; then
     export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
 fi
 

--- a/turtlebot3c-nav-snap/snap/local/ros_network.sh
+++ b/turtlebot3c-nav-snap/snap/local/ros_network.sh
@@ -2,7 +2,7 @@
 
 ROS_MASTER_HOST="$(snapctl get ros-master-host)"
 
-if [[ -z "${ROS_MASTER_URI}" ]]; then
+if [ "${ROS_MASTER_URI}" == "http://localhost:11311" ]; then
     export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
 fi
 

--- a/turtlebot3c-teleop-snap/snap/local/ros_network.sh
+++ b/turtlebot3c-teleop-snap/snap/local/ros_network.sh
@@ -2,7 +2,7 @@
 
 ROS_MASTER_HOST="$(snapctl get ros-master-host)"
 
-if [[ -z "${ROS_MASTER_URI}" ]]; then
+if [ "${ROS_MASTER_URI}" == "http://localhost:11311" ]; then
     export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
 fi
 


### PR DESCRIPTION
The ROS network was not accessible from a different device.

It turns out that `ROS_MASTER_URI` was always set to `"http://localhost:11311"` although we had defined the `ros-master-host` parameter.

In the command chain, the ros-extension script defining `ROS_MASTER_URI="http://localhost:11311"` was called before the `ros_network` script.

```
    command-chain:
    - snap/command-chain/ros1-launch
    - usr/bin/ros_network.sh
    - usr/bin/mux_select_joy_vel.sh

```

