### PR TITLE
fix(ros_network): ros1-launch command-chain is called before ros_network

### DIFF
--- a/snap/local/ros_network.sh
+++ b/snap/local/ros_network.sh
@@ -2,7 +2,7 @@
 
 ROS_MASTER_HOST="$(snapctl get ros-master-host)"
 
-if [[ -z "${ROS_MASTER_URI}" ]]; then
+if [ "${ROS_MASTER_URI}" == "http://localhost:11311" ]; then
     export ROS_MASTER_URI=http://${ROS_MASTER_HOST}:11311
 fi
 if [[ -z "${ROS_HOSTNAME}" ]]; then


### PR DESCRIPTION
Same as https://github.com/canonical/turtlebot3c-snap/pull/45 but different