### PR TITLE
ci: add debugging-tutorial branch

### DIFF
--- a/.github/workflows/monthly.yaml
+++ b/.github/workflows/monthly.yaml
@@ -25,3 +25,7 @@ jobs:
     uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@developer-guide-part2-answer
     with:
       branch-name: developer-guide-part2-answer
+  debugging-tutorial:
+    uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@debugging-tutorial
+    with:
+      branch-name: debugging-tutorial


### PR DESCRIPTION
I created a branch for the [debugging-tutorial](https://github.com/canonical/turtlebot3c-snap/tree/debugging-tutorial)
In order to get this branch monthly built, I added the branch to the monthly CI.