### PR TITLE
fix(monthly): split monthly builds so we won't hit the 20 reusable wo…

### DIFF
--- a/.github/workflows/monthly-1.yaml
+++ b/.github/workflows/monthly-1.yaml
@@ -1,0 +1,16 @@
+name: Monthly-1 # Necessary since there is a limit of 20 reusable workflows
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  part2-answer:
+    uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@developer-guide-part2-answer
+    with:
+      branch-name: developer-guide-part2-answer
+  debugging-tutorial:
+    uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@debugging-tutorial
+    with:
+      branch-name: debugging-tutorial
+

--- a/.github/workflows/monthly.yaml
+++ b/.github/workflows/monthly.yaml
@@ -21,11 +21,4 @@ jobs:
     uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@feature/multi-snap-jazzy
     with:
       branch-name: feature/multi-snap-jazzy
-  part2-answer:
-    uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@developer-guide-part2-answer
-    with:
-      branch-name: developer-guide-part2-answer
-  debugging-tutorial:
-    uses: canonical/turtlebot3c-snap/.github/workflows/snap.yaml@debugging-tutorial
-    with:
-      branch-name: debugging-tutorial
+


### PR DESCRIPTION
Split monthly builds so we won't hit the 20 reusable workflows limit

I divided between the "main" branches and the exercise/debug in another one.

This way, even if in the future we increase the number of reusable workflows in the snap.yaml, it won't be a problem.