### PR TITLE
ci: use root when accessing the map

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -26,7 +26,7 @@ jobs:
 
                     sudo snap services turtlebot3c | grep -E "map-cleaner|timer-activated"
                     if [ $? -eq 0 ]; then
-                        echo "map-cleaner deamon exists"
+                      echo "map-cleaner deamon exists"
                     else
                       echo "map-cleaner does not exist"
                       exit 1
@@ -34,12 +34,12 @@ jobs:
 
                     MAP_FOLDER=/root/snap/turtlebot3c/common/map/
 
-                    touch $MAP_FOLDER/dummy_map.yaml
-                    touch $MAP_FOLDER/dummy_map.pgm
+                    sudo touch $MAP_FOLDER/dummy_map.yaml
+                    sudo touch $MAP_FOLDER/dummy_map.pgm
 
                     sudo snap run turtlebot3c.map-cleaner
 
-                    if [ -z "$(ls -A "$MAP_FOLDER")" ]; then
+                    if [ -z "$(sudo ls -A "$MAP_FOLDER")" ]; then
                       echo "map folder has been cleaned"
                     else
                       echo "Error - map folder was not cleaned"

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -32,8 +32,9 @@ jobs:
                       exit 1
                     fi
 
-                    MAP_FOLDER=/root/snap/turtlebot3c/common/map/
+                    MAP_FOLDER=/root/snap/turtlebot3c/common/map
 
+                    sudo mkdir $MAP_FOLDER
                     sudo touch $MAP_FOLDER/dummy_map.yaml
                     sudo touch $MAP_FOLDER/dummy_map.pgm
 


### PR DESCRIPTION
The monthly CI failed: https://github.com/canonical/turtlebot3c-snap/actions/runs/12565164172

We were accessing the map without root.
Because the map is created by a snap daemon (hence root user), we need sudo to access the map.