### PR TITLE
migrate from deprecated ubuntu-robotics to Canonical

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   snap:
-    uses: ubuntu-robotics/snap_workflows/.github/workflows/snap.yaml@main
+    uses: canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main
     with:
       branch-name: ${{ inputs.branch-name == '' && github.ref || inputs.branch-name }}
       snap-name: turtlebot3c


### PR DESCRIPTION
This was using the old ubuntu-robotics workflow repo.
It started failing due to a deprecated action used in the reusable workflow.