### PR TITLE
[hermes-agent] ci: use Snapcraft 8.x/stable on noetic-devel

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -25,6 +25,7 @@ jobs:
       runs-on: '["ubuntu-latest", "ubuntu-24.04-arm"]'
       lxd-image: "ubuntu:20.04"
       snapcraft-source-subdir: "."
+      snapcraft-channel: "8.x/stable"
       git-ref: ${{ inputs.branch-name == '' && github.ref || inputs.branch-name }}
       snap-test-script: |
             #!/bin/bash


### PR DESCRIPTION
[hermes-agent]

## Summary
- Set `snapcraft-channel: "8.x/stable"` in `.github/workflows/snap.yaml`.
- This prevents Snapcraft 9 from being installed on CI runners for `core20` projects.

## Why
The failing runs show:
- `Base 'core20' is not supported by this version of Snapcraft.`
- Recommended fix from logs: use Snapcraft 8.x channel.

## Evidence
- https://github.com/canonical/turtlebot3c-snap/actions/runs/28486650226/job/84434467145
- https://github.com/canonical/turtlebot3c-snap/actions/runs/28485364139

## Test Plan
- [ ] CI run on this PR succeeds with Snapcraft from `8.x/stable`.
