### PR TITLE
[hermes-agent] ci: migrate snap workflow to GitHub ARM runners (debugging-tutorial)

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -18,7 +18,7 @@ jobs:
   snap:
     uses: canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main
     with:
-      runs-on: '["ubuntu-latest", ["self-hosted", "linux", "ARM64", "large", "noble"]]'
+      runs-on: '["ubuntu-latest", "ubuntu-24.04-arm"]'
       lxd-image: "ubuntu:20.04"
       snapcraft-source-subdir: "."
       snapcraft-channel: "8.x/stable"


### PR DESCRIPTION
[hermes-agent]

## Summary
- migrate `.github/workflows/snap.yaml` from self-hosted ARM labels to GitHub-hosted ARM runners
- keep the existing reusable workflow and job inputs unchanged

## Change
- `runs-on`: `["ubuntu-latest", ["self-hosted", "linux", "ARM64", "large", "noble"]]` → `["ubuntu-latest", "ubuntu-24.04-arm"]`

## Test Plan
- [ ] GitHub Actions CI is green on this PR
