### PR TITLE
[hermes-agent] ci: migrate snap workflow to GitHub ARM runners (feature/multi-snap)

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -37,7 +37,7 @@ jobs:
     secrets:
       snapstore-login: ${{ secrets.STORE_LOGIN }}
     with:
-      runs-on: '["ubuntu-latest", ["self-hosted", "linux", "ARM64", "medium", "noble"]]'
+      runs-on: '["ubuntu-latest", "ubuntu-24.04-arm"]'
       lxd-image: 'ubuntu:20.04'
       snapcraft-source-subdir: "${{ needs.collect_snap_names.outputs.snap-names }}"
       snapcraft-channel: "8.x/stable"


### PR DESCRIPTION
[hermes-agent]

## Summary
- migrate `.github/workflows/snap.yaml` from self-hosted ARM labels to GitHub-hosted ARM runners
- keep the existing reusable workflow and matrix logic unchanged

## Change
- `runs-on`: `["ubuntu-latest", ["self-hosted", "linux", "ARM64", "medium", "noble"]]` → `["ubuntu-latest", "ubuntu-24.04-arm"]`

## Test Plan
- [ ] GitHub Actions CI is green on this PR
