### PR TITLE
[hermes-agent] ci: allow reusable workflow cleanup permissions

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -18,6 +18,9 @@ on:
 
 jobs:
   snap:
+    permissions:
+      contents: read
+      actions: write
     uses: canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main
     secrets:
       snapstore-login: ${{ secrets.STORE_LOGIN }}


### PR DESCRIPTION
[hermes-agent]

## Summary
- add explicit caller permissions on `.github/workflows/snap.yaml` `jobs.snap`:
  - `contents: read`
  - `actions: write`
- keep using `canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main`

## Why
Run `30675605522` fails at startup (no jobs created) because the nested reusable job `cleanup` now requires `actions: write`, while the caller allows `actions: none`.

## Evidence
- failing run: https://github.com/canonical/turtlebot3c-snap/actions/runs/30675605522
- run annotation includes:
  - `The nested job 'cleanup' is requesting 'actions: write', but is only allowed 'actions: none'.`
